### PR TITLE
Add Task documentation hub for investigative notes

### DIFF
--- a/Task/README.md
+++ b/Task/README.md
@@ -1,0 +1,41 @@
+# Task-Dokumentationsknoten
+
+```text
+Task/
+├── README.md
+└── rendering-notes.md
+```
+
+Dieses Verzeichnis bündelt alle laufenden Untersuchungen und Ad-hoc-Analysen für Choo Choo Clicker. Es dient als Arbeitsbereich für Hypothesen, Messungen und Vergleichsnotizen, bevor die Ergebnisse als To-dos oder dauerhafte Dokumentation übernommen werden.
+
+## Zweck & Einbindung
+- **Arbeitsprotokolle bündeln:** Hier werden temporäre Rechercheergebnisse, Debug-Notizen und explorative Erkenntnisse gesammelt.
+- **Verlinkung zu offenen Punkten:** Jede Untersuchung, die zu einer konkreten Maßnahme führt, erhält einen Eintrag im [`todo/`](../todo/README.md)-Verzeichnis. Rückverweise halten den Bezug zwischen Erkenntnissen und To-dos nachvollziehbar.
+- **Strukturierte Ablage:** Einzelne Themen werden als eigene Markdown-Dateien geführt und in diesem README gelistet.
+
+## Struktur & Konventionen
+- **Dateinamensschema:** `Task/<schwerpunkt>-notes.md` für themenspezifische Notizen.
+- **Inhaltliche Mindeststruktur:** Datum, Ausgangsbeobachtung, Analyse, nächste Schritte / Hand-off.
+- **Verlinkungen:** Immer betroffene Module, Screenshots oder externe Messungen referenzieren. Bei neuen To-dos in `todo/` bitte auf beide Richtungen verweisen.
+
+Aktuell vorhandene Dokumente:
+- [`rendering-notes.md`](./rendering-notes.md) – Laufende Sammlung der Rendering-Abweichungen inklusive Querverweise zu betroffenen Modulen.
+
+## Offene Untersuchungen
+Die folgenden Analysen sind vorbereitet und warten auf detaillierte Ausarbeitung:
+- **Sprite-Audit:** Sichtprüfung aller Assets auf Skalierung, Transparenz und Layering-Probleme.
+- **Map-Vergleich:** Gegenüberstellung der In-Game-Karte mit den erwarteten Layouts aus dem User-Wiki.
+- **Rotations-Checks:** Validierung der Sprite-Rotationen gegenüber den Steuerungsereignissen.
+
+**Vorgehen für neue Notizen:**
+1. Eine neue Datei im Muster `Task/<thema>-notes.md` anlegen und hier verlinken.
+2. Einstieg mit Kontext (Datum, Reporter, Bezug) und klarer Problemhypothese.
+3. Beobachtungen, Messungen und Entscheidungen dokumentieren.
+4. Resultierende Maßnahmen als To-do im [`todo/`](../todo/README.md)-Verzeichnis hinterlegen und gegenseitig verlinken.
+5. Wenn das Thema abgeschlossen ist, den Status hier aktualisieren (z. B. „abgeschlossen“ oder Verweis auf finale Dokumentation).
+
+## Querverweise
+- [`todo/README.md`](../todo/README.md) – Kanonische Liste der offenen Aufgaben.
+- Modul-Dokumentationen in `src/` – Für Details zu den betroffenen Implementierungen.
+
+Weitere Unterordner oder Detaildokumente werden bei Bedarf ergänzt und hier aufgenommen.

--- a/Task/rendering-notes.md
+++ b/Task/rendering-notes.md
@@ -1,0 +1,22 @@
+# Rendering-Abweichungen & Beobachtungen
+
+Diese Notizen verfolgen aktuelle Abweichungen zwischen erwartetem und tatsächlichem Rendering. Die Dokumentation dient als Zwischenschritt, bis konkrete Maßnahmen als To-do erfasst und umgesetzt sind.
+
+## Aktueller Befund (Stand: laufende Untersuchung)
+- **UI-Skalierung im Hauptfenster** – Text- und Button-Elemente skalieren auf hochauflösenden Displays unscharf. Vermutete Ursache: Layout- und DPI-Behandlung in [`src/ui/app.py`](../src/ui/app.py).
+- **Sprite-Offsets bei Assets** – Mehrere Fahrzeug-Sprites erscheinen um 1–2 Pixel verschoben, besonders während Animationen. Prüfung der Sprite-Daten und Bounding-Boxes in [`src/assets/sprites.py`](../src/assets/sprites.py) erforderlich.
+- **Kamera-Tracking beim Start** – Beim Initialisieren der Karte springt die Kamera kurzzeitig an eine falsche Position, bevor sie sich fängt. Der initiale Szenenaufbau in [`src/main.py`](../src/main.py) muss auf Timing und Update-Reihenfolge überprüft werden.
+
+## Geplante Vertiefungen
+- Messung der tatsächlichen Sprite-Abmessungen gegenüber den Source-Dateien.
+- Vergleich der Render-Logs zwischen verschiedenen Plattformen (Windows/Linux).
+- Erfassung von Screenshots für Vorher/Nachher-Dokumentation.
+
+## Nächste Schritte & Übergaben
+1. Hypothesen durch Tests oder Debug-Ausgaben verifizieren.
+2. Erkenntnisse als spezifische To-dos im [`todo/`](../todo/README.md)-Verzeichnis erfassen.
+3. Umsetzungsergebnisse in den Modul-Readmes spiegeln; diese Datei anschließend aktualisieren oder archivieren.
+
+## Platz für weitere Beobachtungen
+- _Neue Beobachtungen hier ergänzen (mit Datum, Kontext und betroffenen Modulen)._ 
+


### PR DESCRIPTION
## Summary
- add Task documentation directory with structure and usage guidelines
- document current rendering deviations and reference impacted modules

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d6c97990b48325bc4783dbaa3f1f3d