### PR TITLE
Add UI track sprite selection regression test

### DIFF
--- a/Task/rendering-notes.md
+++ b/Task/rendering-notes.md
@@ -18,5 +18,11 @@ Diese Notizen verfolgen aktuelle Abweichungen zwischen erwartetem und tatsächli
 3. Umsetzungsergebnisse in den Modul-Readmes spiegeln; diese Datei anschließend aktualisieren oder archivieren.
 
 ## Platz für weitere Beobachtungen
-- _Neue Beobachtungen hier ergänzen (mit Datum, Kontext und betroffenen Modulen)._ 
+- _Neue Beobachtungen hier ergänzen (mit Datum, Kontext und betroffenen Modulen)._
+- **2024-05-09** _Track-Sprite-Selektion_: Neuer Pytest
+  [`tests/ui/test_track_sprite_selection.py`](../tests/ui/test_track_sprite_selection.py) bestätigt die
+  erwarteten Sprite-Keys für alle Randzellen des Initial-Rings (Kurven + Gerade). Keine Abweichungen
+  festgestellt.
+  - Offene Frage: Für T-Kreuzungen (`TrackShape.T_JUNCTION`) und Kreuzungen (`TrackShape.CROSS`) fehlen
+    weiterhin explizite Sprite-Mappings im UI-Code und damit Testabdeckung.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,6 +6,9 @@ tests/
 ├── game/
 │   ├── README.md
 │   └── test_train.py
+├── ui/
+│   ├── README.md
+│   └── test_track_sprite_selection.py
 └── world/
     ├── README.md
     ├── test_game_map.py
@@ -17,7 +20,12 @@ Der Ordner `tests/` enthält automatisierte Tests für die Module in [`src/`](..
 
 ## Wichtige Komponenten
 - **`game/`** – Tests für Momentum- und Tick-Logik.
+- **`ui/`** – Headless Rendering-Checks für Sprite- und Layoutlogik.
 - **`world/`** – Tests und Integrationsfälle für das Kartenmodell.
+
+## UI Rendering Checks
+- [`test_track_sprite_selection.py`](ui/test_track_sprite_selection.py) validiert die Sprite-Auswahl
+  entlang der vorinitialisierten Ringstrecke ohne Tk-Abhängigkeiten.
 
 ## Standards & Konventionen
 - Gemeinsame Fixtures gehören in `conftest.py`, sobald mehrere Module sie benötigen.

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -1,0 +1,23 @@
+# UI-Testpaket `tests/ui/`
+
+```text
+tests/ui/
+├── README.md
+└── test_track_sprite_selection.py
+```
+
+## Zweck des Ordners
+Der Ordner `tests/ui/` bündelt UI-nahe Regressionstests, die ohne echte Tk-Oberfläche laufen. Sie
+prüfen insbesondere die Sprite-Auswahl und andere visuelle Ableitungen anhand der Engine-Daten.
+
+## Standards & Konventionen
+- Tests simulieren UI-Interaktionen über Dummy-Objekte oder Helper, sodass kein GUI-Toolkit
+  initialisiert werden muss.
+- Erwartete Sprite-Keys werden stets explizit dokumentiert, damit Abweichungen nachvollziehbar
+  bleiben.
+- Neue Tests erhalten klare Kontext-Kommentare (z. B. Randfälle, Assets) und referenzieren relevante
+  Tickets oder Notizen im Ordner [`Task/`](../../Task/README.md).
+
+## Weiterführende Dokumentation
+- [Hauptübersicht der Tests](../README.md)
+- [Rendering-Notizen & offene Fragen](../../Task/rendering-notes.md)

--- a/tests/ui/test_track_sprite_selection.py
+++ b/tests/ui/test_track_sprite_selection.py
@@ -1,0 +1,61 @@
+"""Regressionstest für die Sprite-Auswahl entlang des vorinitialisierten Kartenrings."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from main import create_engine
+from ui.app import ChooChooApp
+from world import Cell, Direction, TrackPiece, TrackShape
+
+
+@pytest.fixture(scope="module")
+def engine():
+    """Erzeugt den Standard-Enginezustand mit Ringstrecke."""
+
+    return create_engine()
+
+
+def _iter_border_cells(width: int, height: int):
+    """Liefert alle Zellen am Kartenrand ohne Duplikate."""
+
+    border: set[Cell] = set()
+    for x in range(width):
+        border.add((x, 0))
+        border.add((x, height - 1))
+    for y in range(height):
+        border.add((0, y))
+        border.add((width - 1, y))
+    return sorted(border)
+
+
+def test_track_sprite_selection_on_initial_ring(engine):
+    """Alle Randzellen müssen konsistente Sprite-Keys liefern."""
+
+    game_map = engine.game_map
+    dummy_app = SimpleNamespace(engine=engine)
+
+    expected_keys = {
+        frozenset({Direction.NORTH, Direction.SOUTH}): "track_straight_ns",
+        frozenset({Direction.EAST, Direction.WEST}): "track_straight_ew",
+        frozenset({Direction.NORTH, Direction.EAST}): "track_curve_ne",
+        frozenset({Direction.EAST, Direction.SOUTH}): "track_curve_se",
+        frozenset({Direction.SOUTH, Direction.WEST}): "track_curve_sw",
+        frozenset({Direction.WEST, Direction.NORTH}): "track_curve_nw",
+    }
+
+    for cell in _iter_border_cells(game_map.width, game_map.height):
+        piece: TrackPiece | None = game_map.get_track_piece(cell)
+        assert piece is not None, f"Randzelle {cell} sollte Teil des Rings sein"
+        assert piece.shape in {TrackShape.STRAIGHT, TrackShape.CURVE}
+
+        expected_key = expected_keys.get(piece.connections)
+        assert (
+            expected_key is not None
+        ), f"Für die Verbindungen {piece.connections} fehlt eine Sprite-Zuordnung"
+
+        sprite_key = ChooChooApp._select_track_sprite(dummy_app, cell)
+        assert (
+            sprite_key == expected_key
+        ), f"Falscher Sprite-Key für {cell}: erwartet {expected_key}, erhalten {sprite_key}"


### PR DESCRIPTION
## Summary
- add headless UI regression test covering track sprite selection on the initial map ring
- document the new UI test suite and reference it from the test overview
- record rendering verification status and open follow-up questions in the task notes

## Testing
- pytest tests/ui/test_track_sprite_selection.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ca8221848325a268097061d653d1