### PR TITLE
Add central game state reducer and context provider

### DIFF
--- a/docs/loop_notes.md
+++ b/docs/loop_notes.md
@@ -1,0 +1,17 @@
+---
+current_role: documentation
+role_prompt: Prompt/documentation_prompt.md
+last_updated: 2025-09-29
+---
+
+## last_steps
+- Implementer hat den zentralen Spielzustand (Reducer, Kontext, Typen) erstellt und in die App integriert.
+- Momentum- und Gleisaktionen wurden mit Tests abgesichert (impl.define_game_state).
+
+## next_steps
+- Dokumentations-Agent soll die neuen State-Module und deren Nutzung im Projektüberblick und ggf. im README beschreiben.
+- Offene Fragen: Fehlende Projektübersicht (`docs/project_overview.md`) anlegen oder verlinken.
+
+## context
+- Momentum ist aktuell auf 0–10 begrenzt und über Aktionen `addMomentum`, `consumeMomentum`, `setMomentum` steuerbar.
+- `setSwitch` ist nur für Kreuzungen verfügbar und erwartet vorhandene Weichenzuordnung.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
 import "./App.css";
 import { AppLayout } from "./components/layout/AppLayout";
+import { GameStateProvider } from "./state";
 
 function App() {
-  return <AppLayout />;
+  return (
+    <GameStateProvider>
+      <AppLayout />
+    </GameStateProvider>
+  );
 }
 
 export default App;

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,6 +1,9 @@
+import { useGameState } from "../../state";
 import styles from "./AppLayout.module.css";
 
 export function AppLayout() {
+  const { momentum } = useGameState();
+
   return (
     <div className={styles.appLayout}>
       <header className={styles.topBar}>
@@ -8,7 +11,9 @@ export function AppLayout() {
         <div className={styles.resourceSummary}>
           <div className={styles.resourceItem}>
             <span className={styles.resourceLabel}>Momentum</span>
-            <span className={styles.resourceValue}>0 / 10</span>
+            <span className={styles.resourceValue}>
+              {momentum.current} / {momentum.max}
+            </span>
           </div>
           <div className={styles.resourceItem}>
             <span className={styles.resourceLabel}>Ressourcen</span>

--- a/src/state/GameStateContext.tsx
+++ b/src/state/GameStateContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, Dispatch, ReactNode, useContext, useReducer } from "react";
+import { GameState } from "./gameTypes";
+import { createInitialGameState, GameAction, gameReducer } from "./gameReducer";
+
+const GameStateContext = createContext<GameState | undefined>(undefined);
+const GameDispatchContext = createContext<Dispatch<GameAction> | undefined>(undefined);
+
+interface GameStateProviderProps {
+  children: ReactNode;
+  initialState?: GameState;
+}
+
+export function GameStateProvider({ children, initialState }: GameStateProviderProps) {
+  const [state, dispatch] = useReducer(gameReducer, initialState ?? createInitialGameState());
+
+  return (
+    <GameStateContext.Provider value={state}>
+      <GameDispatchContext.Provider value={dispatch}>
+        {children}
+      </GameDispatchContext.Provider>
+    </GameStateContext.Provider>
+  );
+}
+
+export function useGameState(): GameState {
+  const context = useContext(GameStateContext);
+  if (!context) {
+    throw new Error("useGameState must be used within a GameStateProvider");
+  }
+  return context;
+}
+
+export function useGameDispatch(): Dispatch<GameAction> {
+  const context = useContext(GameDispatchContext);
+  if (!context) {
+    throw new Error("useGameDispatch must be used within a GameStateProvider");
+  }
+  return context;
+}
+
+export function useGameStore() {
+  return { state: useGameState(), dispatch: useGameDispatch() };
+}

--- a/src/state/gameReducer.test.ts
+++ b/src/state/gameReducer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { IntersectionTrack, MOMENTUM_MAX, TrackPiece } from "./gameTypes";
+import {
+  coordinateToKey,
+  createInitialGameState,
+  gameReducer,
+  GameAction,
+} from "./gameReducer";
+
+function dispatch(state = createInitialGameState(), action: GameAction) {
+  return gameReducer(state, action);
+}
+
+describe("gameReducer", () => {
+  it("creates an initial state with defaults", () => {
+    const state = createInitialGameState({ width: 8, height: 6 });
+    expect(state.dimensions).toEqual({ width: 8, height: 6 });
+    expect(state.momentum).toEqual({ current: 0, max: MOMENTUM_MAX });
+    expect(state.tracks).toEqual({});
+    expect(state.train.position.x).toBeGreaterThanOrEqual(0);
+    expect(state.train.position.y).toBeGreaterThanOrEqual(0);
+  });
+
+  it("increases momentum up to the maximum", () => {
+    const state = createInitialGameState();
+    const next = dispatch(state, { type: "addMomentum", amount: MOMENTUM_MAX + 5 });
+    expect(next.momentum.current).toBe(MOMENTUM_MAX);
+  });
+
+  it("throws when consuming more momentum than available", () => {
+    const state = createInitialGameState();
+    expect(() => dispatch(state, { type: "consumeMomentum", amount: 1 })).toThrow();
+  });
+
+  it("places and removes tracks on the grid", () => {
+    const state = createInitialGameState({ width: 4, height: 4 });
+    const coordinate = { x: 1, y: 1 };
+    const track: TrackPiece = { type: "straight", connections: ["east", "west"] };
+
+    const withTrack = dispatch(state, { type: "placeTrack", coordinate, track });
+    const key = coordinateToKey(coordinate);
+    expect(withTrack.tracks[key]).toEqual(track);
+
+    const removed = dispatch(withTrack, { type: "removeTrack", coordinate });
+    expect(removed.tracks[key]).toBeUndefined();
+  });
+
+  it("updates switch directions on intersections", () => {
+    const state = createInitialGameState({ width: 5, height: 5 });
+    const coordinate = { x: 2, y: 2 };
+    const intersection: IntersectionTrack = {
+      type: "intersection",
+      connections: ["north", "east", "south", "west"],
+      switches: { north: "east", south: "west" },
+    };
+
+    const withIntersection = dispatch(state, {
+      type: "placeTrack",
+      coordinate,
+      track: intersection,
+    });
+
+    const updated = dispatch(withIntersection, {
+      type: "setSwitch",
+      coordinate,
+      entry: "north",
+      exit: "south",
+    });
+
+    const key = coordinateToKey(coordinate);
+    expect((updated.tracks[key] as IntersectionTrack).switches.north).toBe("south");
+  });
+
+  it("moves the train within grid bounds", () => {
+    const state = createInitialGameState({ width: 3, height: 3 });
+    const moved = dispatch(state, {
+      type: "setTrainPosition",
+      position: { x: 1, y: 2 },
+      facing: "south",
+    });
+
+    expect(moved.train.position).toEqual({ x: 1, y: 2 });
+    expect(moved.train.facing).toBe("south");
+    expect(moved.train.status).toBe("moving");
+  });
+});

--- a/src/state/gameReducer.ts
+++ b/src/state/gameReducer.ts
@@ -1,0 +1,171 @@
+import {
+  Coordinate,
+  Direction,
+  GameState,
+  GridDimensions,
+  IntersectionTrack,
+  MOMENTUM_MAX,
+  TrackPiece,
+} from "./gameTypes";
+
+export type GameAction =
+  | { type: "addMomentum"; amount: number }
+  | { type: "consumeMomentum"; amount: number }
+  | { type: "setMomentum"; value: number }
+  | { type: "placeTrack"; coordinate: Coordinate; track: TrackPiece }
+  | { type: "removeTrack"; coordinate: Coordinate }
+  | { type: "setSwitch"; coordinate: Coordinate; entry: Direction; exit: Direction }
+  | { type: "setTrainPosition"; position: Coordinate; facing?: Direction };
+
+export const DEFAULT_GRID_DIMENSIONS: GridDimensions = { width: 12, height: 12 };
+
+export function coordinateToKey({ x, y }: Coordinate): string {
+  return `${x},${y}`;
+}
+
+function isWithinGrid(coordinate: Coordinate, dimensions: GridDimensions): boolean {
+  return (
+    coordinate.x >= 0 &&
+    coordinate.y >= 0 &&
+    coordinate.x < dimensions.width &&
+    coordinate.y < dimensions.height
+  );
+}
+
+export function createInitialGameState(
+  dimensions: GridDimensions = DEFAULT_GRID_DIMENSIONS,
+): GameState {
+  return {
+    dimensions,
+    tracks: {},
+    momentum: {
+      current: 0,
+      max: MOMENTUM_MAX,
+    },
+    train: {
+      position: {
+        x: Math.floor(dimensions.width / 2),
+        y: Math.floor(dimensions.height / 2),
+      },
+      facing: "east",
+      status: "idle",
+    },
+  };
+}
+
+function ensurePositiveAmount(amount: number, action: string) {
+  if (amount < 0) {
+    throw new Error(`${action} requires a non-negative amount`);
+  }
+}
+
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case "addMomentum": {
+      ensurePositiveAmount(action.amount, "addMomentum");
+      const next = Math.min(state.momentum.current + action.amount, state.momentum.max);
+      if (next === state.momentum.current) {
+        return state;
+      }
+      return {
+        ...state,
+        momentum: {
+          ...state.momentum,
+          current: next,
+        },
+      };
+    }
+    case "consumeMomentum": {
+      ensurePositiveAmount(action.amount, "consumeMomentum");
+      if (action.amount > state.momentum.current) {
+        throw new Error("Cannot consume more momentum than currently available");
+      }
+      return {
+        ...state,
+        momentum: {
+          ...state.momentum,
+          current: state.momentum.current - action.amount,
+        },
+      };
+    }
+    case "setMomentum": {
+      const value = Math.max(0, Math.min(action.value, state.momentum.max));
+      if (value === state.momentum.current) {
+        return state;
+      }
+      return {
+        ...state,
+        momentum: {
+          ...state.momentum,
+          current: value,
+        },
+      };
+    }
+    case "placeTrack": {
+      if (!isWithinGrid(action.coordinate, state.dimensions)) {
+        throw new Error("Cannot place track outside of the grid bounds");
+      }
+      const key = coordinateToKey(action.coordinate);
+      return {
+        ...state,
+        tracks: {
+          ...state.tracks,
+          [key]: action.track,
+        },
+      };
+    }
+    case "removeTrack": {
+      const key = coordinateToKey(action.coordinate);
+      if (!state.tracks[key]) {
+        return state;
+      }
+      const { [key]: _removed, ...rest } = state.tracks;
+      return {
+        ...state,
+        tracks: rest,
+      };
+    }
+    case "setSwitch": {
+      const key = coordinateToKey(action.coordinate);
+      const track = state.tracks[key];
+      if (!track) {
+        throw new Error("Cannot set switch for a missing track");
+      }
+      if (track.type !== "intersection") {
+        throw new Error("Switches can only be updated on intersection tracks");
+      }
+      const intersection: IntersectionTrack = {
+        ...track,
+        switches: {
+          ...track.switches,
+          [action.entry]: action.exit,
+        },
+      };
+      return {
+        ...state,
+        tracks: {
+          ...state.tracks,
+          [key]: intersection,
+        },
+      };
+    }
+    case "setTrainPosition": {
+      if (!isWithinGrid(action.position, state.dimensions)) {
+        throw new Error("Cannot move train outside of the grid bounds");
+      }
+      return {
+        ...state,
+        train: {
+          ...state.train,
+          position: action.position,
+          facing: action.facing ?? state.train.facing,
+          status: "moving",
+        },
+      };
+    }
+    default: {
+      const exhaustive: never = action;
+      return exhaustive;
+    }
+  }
+}

--- a/src/state/gameTypes.ts
+++ b/src/state/gameTypes.ts
@@ -1,0 +1,65 @@
+export type Direction = "north" | "east" | "south" | "west";
+
+export interface Coordinate {
+  x: number;
+  y: number;
+}
+
+export type TrackType = "straight" | "curve" | "intersection";
+
+interface TrackBase {
+  type: TrackType;
+  /**
+   * Directions that are connected by this track piece. For example, a straight
+   * horizontal segment would connect west ↔ east.
+   */
+  connections: Direction[];
+}
+
+export interface StraightTrack extends TrackBase {
+  type: "straight";
+}
+
+export interface CurveTrack extends TrackBase {
+  type: "curve";
+}
+
+export interface IntersectionTrack extends TrackBase {
+  type: "intersection";
+  /**
+   * Mapping for each incoming direction to the outgoing direction the switch
+   * currently routes to.
+   */
+  switches: Partial<Record<Direction, Direction>>;
+}
+
+export type TrackPiece = StraightTrack | CurveTrack | IntersectionTrack;
+
+export interface MomentumState {
+  current: number;
+  max: number;
+}
+
+export type TrainStatus = "idle" | "moving" | "stopped";
+
+export interface TrainState {
+  position: Coordinate;
+  facing: Direction;
+  status: TrainStatus;
+}
+
+export interface GridDimensions {
+  width: number;
+  height: number;
+}
+
+export type TrackMap = Record<string, TrackPiece>;
+
+export interface GameState {
+  dimensions: GridDimensions;
+  tracks: TrackMap;
+  momentum: MomentumState;
+  train: TrainState;
+}
+
+export const MOMENTUM_MAX = 10;

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,3 @@
+export * from "./gameTypes";
+export * from "./gameReducer";
+export * from "./GameStateContext";


### PR DESCRIPTION
## Summary
- introduce typed models for tracks, momentum, train state and grid metadata
- add a reducer-driven game state store with React context provider and integrate it into the app layout
- cover core momentum, track and train actions with unit tests and document progress in loop notes

## Testing
- npm test *(fails: vitest not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9113258408325abd72bd4dd727636