### PR TITLE
Document game state architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Der grundlegende Gameplay Loop besteht darin, den zug über eine aus einem Grid 
 
 Die UI besteht aus drei Komponenten. Einem Karten Fenster links, einer Menü Leiste mit resourcen trackern oben und einem Ui Panel rechts. Die Karte enthält die graphische Darstellung der Welt, das Ui panel die Klicker-menü elemente.
 
+## Architektur & Spielzustand
+
+- **State-Management:** `src/state/gameReducer.ts` bündelt alle Spielaktionen (Momentum, Gleise, Weichen, Zugbewegung). Der Reducer wird über den `GameStateProvider` (`src/state/GameStateContext.tsx`) als React Context bereitgestellt.
+- **Typisierung:** Gemeinsame Datentypen liegen in `src/state/gameTypes.ts` und werden über `src/state/index.ts` re-exportiert.
+- **Initialzustand:** `createInitialGameState` erzeugt ein 12×12-Grid, setzt den Zug mittig und begrenzt Momentum standardmäßig auf 10.
+- **Tests:** `src/state/gameReducer.test.ts` prüft Momentum-Grenzen, Gleisplatzierung, Weichen-Updates und Zugbewegungen.
+
+Weitere Details zur Zielvision und Architektur findest du in `docs/project_overview.md`.
+
 ## Entwicklung
 
 ```bash

--- a/docs/loop_notes.md
+++ b/docs/loop_notes.md
@@ -1,16 +1,16 @@
 ---
-current_role: documentation
-role_prompt: Prompt/documentation_prompt.md
+current_role: supervisor
+role_prompt: Prompt/supervisor_prompt.md
 last_updated: 2025-09-29
 ---
 
 ## last_steps
-- Implementer hat den zentralen Spielzustand (Reducer, Kontext, Typen) erstellt und in die App integriert.
-- Momentum- und Gleisaktionen wurden mit Tests abgesichert (impl.define_game_state).
+- Dokumentations-Agent hat `docs/project_overview.md` erstellt und den Spielzustand (Reducer, Kontext, Typen, Tests) beschrieben.
+- README um Abschnitt zur Architektur und Verweis auf den Projektüberblick erweitert.
 
 ## next_steps
-- Dokumentations-Agent soll die neuen State-Module und deren Nutzung im Projektüberblick und ggf. im README beschreiben.
-- Offene Fragen: Fehlende Projektübersicht (`docs/project_overview.md`) anlegen oder verlinken.
+- Supervisor soll neue Dokumentation gegen aktuellen Code prüfen und offene Punkte für UI/State-Integration notieren.
+- Validieren, ob weitere Artefakte (z. B. Changelog, Tasks) aktualisiert werden müssen.
 
 ## context
 - Momentum ist aktuell auf 0–10 begrenzt und über Aktionen `addMomentum`, `consumeMomentum`, `setMomentum` steuerbar.

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -1,0 +1,36 @@
+---
+id: project_overview
+title: Projektüberblick
+status: draft
+date: 2025-09-29
+tags: [overview, architecture, state-management]
+---
+
+# Choo Choo Clicker – Projektüberblick
+
+## Zielbild & Nutzererlebnis
+- Referenzvision: `docs/intended_experience/overview.md` beschreibt das entspannte Clicker-Erlebnis mit Kurbel-Momentum und frei platzierbaren Schienen.
+- Fokus: Eine lokal laufende React-Anwendung, die Momentum-Management, Gleisbau und Zugsteuerung in einem klar strukturierten UI vereint.
+
+## Technische Architektur
+- **Frontend-Stack:** Vite + React + TypeScript (lokale SPA).
+- **State-Management:** Zentraler Reducer (`src/state/gameReducer.ts`) plus React Context (`src/state/GameStateContext.tsx`) stellen Spielzustand und Aktionen bereit.
+- **Typing:** Gemeinsame Datentypen liegen in `src/state/gameTypes.ts` und werden via `src/state/index.ts` re-exportiert.
+- **Testing:** Vitest-Suite `src/state/gameReducer.test.ts` deckt Kernaktionen (Momentum, Gleise, Weichen, Zugbewegung) ab.
+
+## Spielzustand & Aktionen
+- `createInitialGameState` erzeugt ein 12×12-Grid mit leerem Gleisnetz, Momentum-Limit (0–10) und einem zentral positionierten Zug.
+- Momentum-Aktionen (`addMomentum`, `consumeMomentum`, `setMomentum`) validieren Grenzen, so dass nie mehr als das Maximalmomentum gespeichert oder verbraucht wird.
+- Gleisaktionen (`placeTrack`, `removeTrack`) verwalten das `tracks`-Mapping, wobei Koordinaten außerhalb des Grids abgefangen werden.
+- `setSwitch` aktualisiert Weichen ausschließlich für Kreuzungssegmente und verhindert Fehlkonfigurationen für andere Gleisarten.
+- `setTrainPosition` begrenzt Zugbewegungen auf gültige Rasterfelder und markiert den Zugstatus als `moving`.
+
+## Integration im React-Tree
+- `GameStateProvider` kapselt `useReducer` und stellt `state`/`dispatch` via getrennten Contexts bereit.
+- Hilfshooks `useGameState`, `useGameDispatch`, `useGameStore` verhindern Fehlverwendung außerhalb des Providers.
+- Komponenten importieren State-Funktionen über `src/state/index.ts`, wodurch Tests und UI denselben Vertrag teilen.
+
+## Offene Arbeiten / Roadmap
+- UI muss noch konkreten Zugriff auf das State-Modul erhalten (z. B. Canvas-/Panel-Komponenten anbinden).
+- Momentum- und Gleisinteraktionen im UI benötigen Integrationstests, sobald die visuellen Module stehen.
+- Dokumentation der Rendering- und UI-Module ergänzen, sobald diese implementiert sind.

--- a/memory/session_2025-09-29_documentation.md
+++ b/memory/session_2025-09-29_documentation.md
@@ -1,0 +1,20 @@
+---
+role: documentation
+date: 2025-09-29
+tags: [documentation, state-management]
+---
+
+# Dokumentationszusammenfassung (2025-09-29)
+
+## Erledigte Arbeiten
+- `docs/project_overview.md` angelegt und Kernmodule des Spielzustands dokumentiert (Reducer, Context, Typen, Tests, offene Arbeiten).
+- README um Abschnitt "Architektur & Spielzustand" ergänzt und auf den neuen Projektüberblick verwiesen.
+- Loop-Übergabe vorbereitet: nächster Schritt ist Supervisor-Review der frischen Dokumentation.
+
+## Entscheidungsnotizen
+- Fokus der Dokumentation liegt auf der neuen State-Schicht; UI-Module bleiben vorerst als offene Dokumentationsaufgabe markiert.
+- Keine ADR nötig, da ausschließlich beschreibende Artefakte ergänzt wurden.
+
+## Offene Punkte & Empfehlungen
+- Supervisor soll Dokumente gegen Codestand prüfen und Feedback zu eventuellen Lücken geben.
+- Sobald UI-Integration steht, ergänzende Dokumente für Rendering-Architektur und Interaktionsdesign erstellen.


### PR DESCRIPTION
## Summary
- create a project overview document that outlines the new game state reducer, context, and typing modules
- expand the README with an architecture section and link to the detailed overview
- log the documentation work in session notes and update loop notes for the supervisor handoff

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d9153e5fa88325a1200e07cca96e63