### PR TITLE
Add pre-run and role handover checklists

### DIFF
--- a/Prompt/checklists/pre_run.md
+++ b/Prompt/checklists/pre_run.md
@@ -1,0 +1,33 @@
+---
+id: checklist_pre_run
+title: Pre-Run Checklist
+author: Autonomous Prompt Maintainer
+date: 2025-09-28
+tags: [process, startup]
+status: active
+---
+
+## Ziel
+Diese Checkliste stellt sicher, dass vor jeder Session alle globalen Pflichtschritte eingehalten werden, damit die Rollenarbeit konsistent, sicher und nachvollziehbar bleibt.
+
+## Pflichtschritte vor dem Start
+1. **Repository-Struktur prüfen**
+   - Vergleiche die aktuelle Struktur mit den Vorgaben in [`Prompt/README.md#Dokumentationsstruktur`](../README.md#dokumentationsstruktur) und den Richtlinien aus dem [`Prompt/guides/StyleGuide.md`](../guides/StyleGuide.md).
+   - Dokumentiere Abweichungen in den Loop-Notizen und plane Korrekturen.
+2. **Loop-Notizen laden und aktualisieren**
+   - Öffne [`Prompt/loop_notes.md`](../loop_notes.md), lese `last_steps`, `next_steps`, `blockers` und `decision_log`.
+   - Setze `current_role` auf deine aktive Rolle und verlinke das passende Rollen-Template gemäß [`Prompt/AGENTS.md`](../AGENTS.md).
+3. **Response-Contract aktivieren**
+   - Orientiere dich an [`Prompt/templates/Response-Contracts.md`](../templates/Response-Contracts.md) und strukturiere alle Antworten strikt nach „Deliverable → Begründung → Nächste Schritte“.
+   - Bestätige, dass alle geplanten Outputs dieses Format einhalten und in den Loop-Notizen erwähnt sind.
+4. **Guardrails verankern**
+   - Lies die Sicherheitsvorgaben aus [`Prompt/policies/guardrails.md`](../policies/guardrails.md) und prüfe, ob anstehende Schritte damit konform sind.
+   - Notiere Sicherheitsrisiken oder offene Fragen als Blocker und eskaliere bei Bedarf.
+
+## Validierung vor dem ersten Output
+- **Template-Verweise testweise öffnen**: Stelle sicher, dass alle in dieser Checkliste referenzierten Dokumente verfügbar sind und die aktuellste Version widerspiegeln.
+- **Konfliktprüfung gemäß Retrieval-Priorität**: Falls Informationen kollidieren, folge dem Schema aus [`Prompt/policies/retrieval_priority.md`](../policies/retrieval_priority.md) und dokumentiere Entscheidungen im `decision_log`.
+- **Werkzeug- und Testbereitschaft**: Bestätige, dass notwendige Tools, Testbefehle und Zugangsdaten bereitstehen und den Guardrails entsprechen.
+
+## Abschluss
+Erst wenn alle Schritte erfüllt und dokumentiert wurden, darf die produktive Arbeit beginnen. Aktualisiere die Loop-Notizen mit dem Validierungsstatus und bestätige, dass der Response-Contract aktiv ist.

--- a/Prompt/checklists/role_handover.md
+++ b/Prompt/checklists/role_handover.md
@@ -1,0 +1,47 @@
+---
+id: checklist_role_handover
+title: Rollen-Übergaben Checkliste
+author: Autonomous Prompt Maintainer
+date: 2025-09-28
+tags: [process, handover]
+status: active
+---
+
+## Zweck
+Diese Checkliste beschreibt die verpflichtenden Übergaben zwischen den Rollen Visionary → Planner → Architect → Engineer → Reviewer → Supervisor → Visionary. Jede Übergabe stellt sicher, dass Loop-Notizen, Artefakte und Sicherheitsrichtlinien konsistent bleiben.
+
+## Allgemeine Prinzipien
+- **Loop-Notizen als Single Source of Truth:** Vor jeder Übergabe aktualisiert die abgebende Rolle [`Prompt/loop_notes.md`](../loop_notes.md) (Felder `current_role`, `last_steps`, `next_steps`, `blockers`, `validation_state`, `decision_log`).
+- **Response-Contract-Konformität:** Übergabeberichte folgen dem Schema aus [`Prompt/templates/Response-Contracts.md`](../templates/Response-Contracts.md) – auch wenn keine großen Änderungen anstehen.
+- **Guardrails bestätigen:** Jede Rolle verweist vor der Übergabe auf [`Prompt/policies/guardrails.md`](../policies/guardrails.md) und bestätigt die Einhaltung sicherheitsrelevanter Vorgaben.
+- **Retrieval-Priorität beachten:** Konflikte werden gemäß [`Prompt/policies/retrieval_priority.md`](../policies/retrieval_priority.md) dokumentiert und mit Quellen versehen.
+
+## Übergaben im Detail
+### Visionary → Planner
+- Visionary fasst die Vision laut [`Prompt/roles/visionary.md`](../roles/visionary.md) zusammen und verlinkt geänderte Wiki-Seiten.
+- Planner bestätigt, dass Aufgabenableitungen im Rollenprompt [`Prompt/roles/planner.md`](../roles/planner.md) abgedeckt sind und offene Fragen als Tickets/Blocker vorliegen.
+
+### Planner → Architect
+- Planner liefert priorisierte Tasks mit klaren Akzeptanzkriterien (siehe [`Prompt/roles/planner.md`](../roles/planner.md)).
+- Architect prüft Architekturimplikationen gemäß [`Prompt/roles/architect.md`](../roles/architect.md) und ergänzt technische Annahmen oder ADR-Hinweise.
+
+### Architect → Engineer
+- Architect übergibt Architekturentscheidungen inklusive Referenzen zu ADRs/Design-Notizen.
+- Engineer verifiziert gemäß [`Prompt/roles/engineer.md`](../roles/engineer.md), dass Implementierungsplan, Tests und Guardrails klar sind.
+
+### Engineer → Reviewer
+- Engineer liefert Code, Tests und Dokumentation inklusive Testnachweise.
+- Reviewer kontrolliert nach [`Prompt/roles/reviewer.md`](../roles/reviewer.md) die Qualität, stellt Fragen zum Response-Contract und notiert Findings in den Loop-Notizen.
+
+### Reviewer → Supervisor
+- Reviewer dokumentiert Freigabeempfehlung oder Blocker.
+- Supervisor nutzt [`Prompt/roles/supervisor.md`](../roles/supervisor.md), um Qualitätssicherung, Eskalationen und Abschlussentscheidungen festzuhalten.
+
+### Supervisor → Visionary
+- Supervisor bestätigt abgeschlossene Arbeiten, aktualisiert `validation_state` und benennt strategische Implikationen.
+- Visionary übernimmt die Ergebnisse, aktualisiert die Vision (siehe [`Prompt/roles/visionary.md`](../roles/visionary.md)) und startet den nächsten Loop.
+
+## Abschlusscheck pro Übergabe
+- Response-Contract-Abschnitt im Übergabedokument ist vollständig (Deliverable, Begründung, Nächste Schritte).
+- Alle referenzierten Artefakte sind im Repository versioniert und verlinkt.
+- Guardrail- und Sicherheitsprüfungen dokumentiert; offene Risiken als Blocker erfasst.


### PR DESCRIPTION
## Summary
- add a pre-run checklist covering structure, loop notes, response contract, and guardrails
- document role handover checkpoints across the full Visionary → Supervisor cycle
- link both checklists to the relevant templates and policies for quick navigation

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d9293877788325b213a400f1da73df