### PR TITLE
Add documentation templates and backlog schema

### DIFF
--- a/Prompt/templates/Response-Contracts.md
+++ b/Prompt/templates/Response-Contracts.md
@@ -1,0 +1,14 @@
+# Response Contract
+
+> Nutze diese Vorlage für jede Agentenantwort. Fülle alle drei Abschnitte aus, fasse dich präzise und beginne immer mit dem Deliverable.
+
+## Deliverable
+- Ergebnis oder Artefakt in einem Satz beschreiben.
+
+## Begründung
+- Zentrale Quellen, Tests oder Überprüfungen nennen.
+- Entscheidende Abwägungen kurz erläutern.
+
+## Nächste Schritte
+- Konkrete, prüfbare To-dos auflisten.
+- Blocker oder offene Fragen explizit kennzeichnen.

--- a/Prompt/templates/adr.md
+++ b/Prompt/templates/adr.md
@@ -1,0 +1,21 @@
+---
+id: ADR-YYYYMMDD-###
+title: ""
+status: proposed|accepted|rejected|superseded
+date: YYYY-MM-DD
+deciders: []
+consulted: []
+---
+
+## Kontext
+- Problemstellung und Rahmenbedingungen.
+
+## Entscheidung
+- Getroffene Wahl und Alternativen.
+
+## Konsequenzen
+- Positive Effekte.
+- Negative Effekte oder Risiken.
+
+## Nachverfolgung
+- Bezug zu Tickets, Commits oder Dokumenten.

--- a/Prompt/templates/backlog.schema.json
+++ b/Prompt/templates/backlog.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/backlog.schema.json",
+  "$comment": "Backlog-Einträge werden außerhalb des Prompt-Pakets verwaltet; dieses Schema dient nur zur Validierung.",
+  "title": "Backlog Entry",
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "status",
+    "created_at"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stabile eindeutige Kennung, z. B. B-20240101-001."
+    },
+    "title": {
+      "type": "string",
+      "description": "Kurzbeschreibung des Eintrags."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "open",
+        "blocked",
+        "in_progress",
+        "done"
+      ],
+      "description": "Aktueller Bearbeitungsstatus."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Erstellungszeitpunkt im ISO-8601-Format."
+    },
+    "owner": {
+      "type": "string",
+      "description": "Verantwortliche Person oder Rolle."
+    },
+    "priority": {
+      "type": "string",
+      "description": "Priorität wie P0, P1 oder P2."
+    },
+    "deps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "IDs der abhängigen Tickets oder Backlog-Einträge."
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Schlagwörter zur Kategorisierung."
+    },
+    "source": {
+      "type": "string",
+      "description": "Ursprung wie human, system oder external."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Kurzfassung des aktuellen Stands."
+    },
+    "language": {
+      "type": "string",
+      "description": "Sprachcode nach ISO 639-1."
+    }
+  },
+  "additionalProperties": false
+}

--- a/Prompt/templates/changelog.md
+++ b/Prompt/templates/changelog.md
@@ -1,0 +1,24 @@
+---
+version: 0.0.0
+release_date: YYYY-MM-DD
+status: draft|released
+---
+
+## Überblick
+- Kurzbeschreibung der Änderungen.
+
+## Änderungen
+### Added
+- Neue Funktionalitäten.
+
+### Changed
+- Anpassungen oder Verbesserungen.
+
+### Fixed
+- Behebbare Fehler.
+
+### Removed
+- Entfernte Komponenten.
+
+## Auswirkungen
+- Risiken, Migrationshinweise oder Follow-up-Aufgaben.

--- a/Prompt/templates/clarification.md
+++ b/Prompt/templates/clarification.md
@@ -1,0 +1,19 @@
+---
+id: CL-YYYYMMDD-###
+status: open|resolved
+raised_by: ""
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+related_item: "ticket|task|adr|other"
+---
+
+## Fehlende Information
+- Welche Daten oder Entscheidungen fehlen?
+
+## Auswirkung
+- Warum blockiert der Mangel die Arbeit?
+
+## Gewünschte Klärung
+- Konkrete Fragen oder benötigte Entscheidungen.
+
+## Auflösung
+- Dokumentiere Ergebnis, Datum und Quelle.

--- a/Prompt/templates/ticket.md
+++ b/Prompt/templates/ticket.md
@@ -1,0 +1,24 @@
+---
+id: T-YYYYMMDD-###
+title: ""
+priority: P0|P1|P2
+status: open|blocked|in_progress|done
+created_at: "YYYY-MM-DDTHH:MM:SSZ"
+source: human|system|external
+assignee: ""
+tags: []
+---
+
+## Kontext
+- Ausgangslage und Motivation.
+
+## Aufgaben
+- [ ] Schritt 1
+- [ ] Schritt 2
+
+## Akzeptanzkriterien
+- Kriterium 1
+- Kriterium 2
+
+## Risiken & Fragen
+- Offene Punkte, die Clarifications erfordern könnten.


### PR DESCRIPTION
## Summary
- add a response contract template with usage guidance
- provide markdown templates for tickets, ADRs, changelog entries, and clarifications
- supply a JSON schema for backlog entries noting that backlog data lives outside the prompt package

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d92b1785b48325a3600ee3e2b8d466