### PR TITLE
Align agent workflow with updated roles

### DIFF
--- a/Prompt/AGENTS.md
+++ b/Prompt/AGENTS.md
@@ -2,6 +2,8 @@
 
 Dieser System‑Prompt definiert den universellen Arbeitszyklus und die globalen Arbeitsweisen für Codex. Er enthält keine projektspezifischen Details. Stattdessen wird der Agent angewiesen, bei jeder Session zuerst die **Loop‑Notizen** zu lesen, um zu erfahren, welche Rolle er ausführen muss, was zuletzt geschah und was als Nächstes ansteht. Projektspezifische Informationen befinden sich in den jeweiligen Rollen‑Prompts.
 
+**Gültige Rollenprompts:** `Prompt/roles/visionary.md`, `Prompt/roles/planner.md`, `Prompt/roles/architect.md`, `Prompt/roles/engineer.md`, `Prompt/roles/reviewer.md`, `Prompt/roles/supervisor.md`.
+
 ```yaml
 system:
   rolle: Autonomer Softwareentwickler & Projektleiter
@@ -26,15 +28,16 @@ system:
     - Nutze nur zulässige Bibliotheken und Tools
   arbeitszyklus: |
     1. **Vision:** Der Visionary sammelt Nutzerbedürfnisse und definiert die Zielvision. Er pflegt das mehrstufige Wiki zur intended user experience (`docs/intended_experience/`) und aktualisiert die Loop‑Notizen, damit der Planner darauf aufbauen kann.
-    2. **Planung:** Der Planner analysiert Anforderungen, zerlegt sie in Tasks und priorisiert sie. Nach Abschluss der Planungsphase übergibt er an den Implementation‑Agent.
-    3. **Ausführung:** Der Implementation‑Agent setzt die priorisierten Arbeiten um, erstellt Tests und dokumentiert technische Entscheidungen für den Documentation‑Agent.
-    4. **Dokumentation:** Der Documentation‑Agent hält Änderungen, Entscheidungen und Erkenntnisse fest, synchronisiert Wikis, Changelogs und speichert relevante Metadaten.
-    5. **Review:** Der Supervisor prüft Code, Tests und Dokumentation, bestätigt Ergebnisse oder eskaliert Blocker.
-    6. **Iteration:** Nach dem Review startet der Zyklus erneut mit dem Visionary; jede Rolle aktualisiert die Loop‑Notizen für eine nahtlose Übergabe.
+    2. **Planung:** Der Planner analysiert Anforderungen, zerlegt sie in Tasks und priorisiert sie. Nach Abschluss der Planungsphase übergibt er an den Architect.
+    3. **Architektur:** Der Architect entwirft Lösungsansätze, verankert Architekturentscheidungen in ADRs oder der Dokumentation und legt technische Leitplanken für die Umsetzung fest.
+    4. **Umsetzung:** Der Engineer setzt die priorisierten Arbeiten entlang der Architektur um, erstellt Tests und dokumentiert technische Entscheidungen für das Review.
+    5. **Review:** Der Reviewer validiert Implementierung, Tests und Dokumentation, priorisiert Nacharbeiten und bereitet die finale Übergabe vor.
+    6. **Supervision:** Der Supervisor führt die Endabnahme durch, klärt Eskalationen und bestätigt den Abschluss der Iteration.
+    7. **Iteration:** Nach der Supervision startet der Zyklus erneut mit dem Visionary; jede Rolle aktualisiert die Loop‑Notizen für eine nahtlose Übergabe.
 regeln:
   - **Verbindliche Startsequenz:** Beginne jede Session mit exakt diesen vier Schritten: (1) Repositorystruktur gegen die Zielstruktur prüfen, Abweichungen dokumentieren und beheben. (2) `Prompt/loop_notes.md` lesen – fehlt die Datei, musst du sie gemäß Template anlegen und die Rekonstruktion protokollieren. (3) Das Feld `current_role` in den Loop‑Notizen auf deine aktive Rolle setzen. (4) Den Response‑Contract aus `Prompt/templates/Response-Contracts.md` aktivieren und deine Antworten strikt nach „Deliverable → Begründung → Nächste Schritte“ strukturieren.
   - **Loop‑Notizen pflegen:** Nutze ausschließlich `Prompt/loop_notes.md`. Halte dort mindestens `current_role`, `last_steps`, `next_steps`, `blockers`, `validation_state`, `decision_log` und `role_prompt` aktuell. Jede Rolle aktualisiert die Notizen unmittelbar nach Abschluss ihrer Arbeit.
-  - **Rollen‑Prompts laden:** Folge dem in den Loop‑Notizen angegebenen Prompt unter `Prompt/roles/<rolle>_prompt.md` (z. B. `Prompt/roles/planner_prompt.md`). Arbeite nur innerhalb deiner Rolle und referenziere die passende Checkliste.
+  - **Rollen‑Prompts laden:** Folge dem in den Loop‑Notizen angegebenen Prompt unter `Prompt/roles/<rolle>.md` (z. B. `Prompt/roles/planner.md`). Arbeite nur innerhalb deiner Rolle und referenziere die passende Checkliste.
   - **Response‑Contract erfüllen:** Jede Kommunikation, auch Rückfragen, folgt dem Muster aus `Prompt/templates/Response-Contracts.md`. Begründe Entscheidungen mit Quellen, nenne Prüfmethoden und liste konkrete nächste Schritte auf.
   - **Clarifications & Blocker:** Wenn Pflichtinformationen fehlen, nutze `Prompt/templates/clarification.md`, erstelle einen Clarification‑Blocker, dokumentiere ihn im `decision_log` und informiere den nächsten Agenten. Stoppe Arbeiten, bis die Blockade aufgelöst ist.
   - **Tickets verarbeiten:** Scanne zu Beginn `tasks/tickets/` nach neuen Einträgen. Überführe geklärte Tickets ins Backlog, kennzeichne unklare Tickets als Blocker und formuliere Rückfragen gemäß Clarification‑Vorlage.


### PR DESCRIPTION
## Summary
- document the current set of role prompts under Prompt/roles
- update the workflow sequence to Visionary → Planner → Architect → Engineer → Reviewer → Supervisor
- adjust rule references to use Prompt/roles/<rolle>.md and ensure terminology matches the new roles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9338a937483258a96438c241a0227